### PR TITLE
Fix flake8 errors

### DIFF
--- a/tests/functional/test_BugzillaBug.py
+++ b/tests/functional/test_BugzillaBug.py
@@ -8,6 +8,7 @@ from estuary.models.bugzilla import BugzillaBug
 
 @pytest.mark.parametrize("id", [("11111"), ("22222")])
 def test_load_BugzillaBug(id):
+    """Test that a Bugzilla Bug can be created and loaded."""
     BugzillaBug.get_or_create({"id_": id})
     payload = {
         "query": "MATCH (node:BugzillaBug) WHERE node.id = {id} RETURN node.id",

--- a/tests/functional/test_ProductVersion.py
+++ b/tests/functional/test_ProductVersion.py
@@ -8,6 +8,7 @@ from estuary.models.productversion import ProductVersion
 
 @pytest.mark.parametrize("name", [("8.4.0.0"), ("8.5.0.0")])
 def test_load_ProductVersion(name):
+    """Test that a product version can be create and loaded."""
     ProductVersion.get_or_create({"name": name})
     payload = {
         "query": "MATCH (node:ProductVersion) WHERE node.name = {name} RETURN node.name",

--- a/tests/infra/test_neo4j.py
+++ b/tests/infra/test_neo4j.py
@@ -2,6 +2,7 @@ import docker
 
 
 def test_apoc_plugin_installed():
+    """Test that APOC plugin is installed."""
     client = docker.from_env()
     db_container = client.containers.get('db')
     res = db_container.exec_run(

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,5 +1,4 @@
 docker
-flake8
 isort
 mock
 requests

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -16,10 +16,6 @@ docker==4.4.4 \
     --hash=sha256:d3393c878f575d3a9ca3b94471a3c89a6d960b35feb92f033c0de36cc9d934db \
     --hash=sha256:f3607d5695be025fa405a12aca2e5df702a57db63790c73b927eb6a94aac60af
     # via -r tests/requirements.in
-flake8==3.9.0 \
-    --hash=sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff \
-    --hash=sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0
-    # via -r tests/requirements.in
 idna==2.10 \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
@@ -28,22 +24,10 @@ isort==5.8.0 \
     --hash=sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6 \
     --hash=sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d
     # via -r tests/requirements.in
-mccabe==0.6.1 \
-    --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
-    --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
-    # via flake8
 mock==4.0.3 \
     --hash=sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62 \
     --hash=sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc
     # via -r tests/requirements.in
-pycodestyle==2.7.0 \
-    --hash=sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068 \
-    --hash=sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef
-    # via flake8
-pyflakes==2.3.1 \
-    --hash=sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3 \
-    --hash=sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db
-    # via flake8
 requests==2.25.1 \
     --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804 \
     --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e

--- a/tests/unit/test_ProductVersion.py
+++ b/tests/unit/test_ProductVersion.py
@@ -5,6 +5,6 @@ from estuary.models.productversion import ProductVersion
 
 @pytest.mark.parametrize("name", [("8.4.0.0"), ("8.5.0.0")])
 def test_ProductVersion(name):
-    """Test ProductVersion"""
+    """Test ProductVersion."""
     productversion = ProductVersion(name=name).save()
     assert productversion.name == name

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,10 @@ commands = pytest --noconftest tests/functional
 
 [testenv:flake8]
 commands = flake8
+skip_install = true
+deps =
+    flake8==3.8.0
+    flake8-docstrings==1.5.0
 
 [testenv:isort]
 commands = isort . --check --diff


### PR DESCRIPTION
There were some flake8-docstrings errors that need to be corrected. This was not caught before because flake8-docstrings was not installed in the tox environment. This is addressed in the second commit.