### PR TITLE
Run isort by default with tox

### DIFF
--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,4 +1,3 @@
 docker
-isort
 mock
 requests

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -20,10 +20,6 @@ idna==2.10 \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \
     --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
     # via requests
-isort==5.8.0 \
-    --hash=sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6 \
-    --hash=sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d
-    # via -r tests/requirements.in
 mock==4.0.3 \
     --hash=sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62 \
     --hash=sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py39, flake8, safety
+envlist = py36, py39, flake8, isort, safety
 skipsdist = true
 skip_missing_interpreters = true
 
@@ -18,6 +18,9 @@ deps =
 
 [testenv:isort]
 commands = isort . --check --diff
+skip_install = true
+deps =
+    isort==5.8.0
 
 [testenv:infra]
 commands = pytest --noconftest tests/infra


### PR DESCRIPTION
Additionally, the test dependencies are not installed
by tox for the isort test. This will speed things up.