### PR TITLE
Upgrade the base images to use UBI 8

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -1,13 +1,10 @@
-FROM fedora:30
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 LABEL maintainer="Factory 2.0"
 
-RUN dnf -y install \
-    --setopt=deltarpm=0 \
-    --setopt=install_weak_deps=false \
-    --setopt=tsflags=nodocs \
+RUN microdnf -y install \
     bash \
     python3-pip \
-    && dnf clean all
+    && microdnf clean all
 # This will allow a non-root user to install a custom root CA at run-time
 RUN chmod 777 /etc/pki/tls/certs/ca-bundle.crt
 WORKDIR /src

--- a/docker/Dockerfile-scrapers
+++ b/docker/Dockerfile-scrapers
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 LABEL maintainer="Factory 2.0"
 
 ENV SCRAPER=all \
@@ -11,16 +11,13 @@ ENV SCRAPER=all \
     WAIT_FOR=0
 
 WORKDIR /src
-RUN dnf -y install \
-    --setopt=deltarpm=0 \
-    --setopt=install_weak_deps=false \
-    --setopt=tsflags=nodocs \
+RUN microdnf -y install \
     bash \
     gcc \
     libpq-devel \
     python3-devel \
     python3-pip \
-    && dnf clean all
+    && microdnf clean all
 # This will allow a non-root user to install a custom root CA at run-time
 RUN chmod 777 /etc/pki/tls/certs/ca-bundle.crt
 COPY . .

--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -1,14 +1,10 @@
-FROM fedora:30
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-# TODO: Replace the Koji URL once the following is stable https://bodhi.fedoraproject.org/updates/FEDORA-2018-c929a49b1b
-RUN dnf -y install \
-    --setopt=deltarpm=0 \
-    --setopt=install_weak_deps=false \
-    --setopt=tsflags=nodocs \
+RUN microdnf -y install \
     bash \
     nmap-ncat \
     python3-pip \
-    && dnf clean all
+    && microdnf clean all
 
 COPY tests/requirements.txt /tmp/requirements.txt
 VOLUME /src


### PR DESCRIPTION
Fedora 30 is not supported anymore and now
that dependencies are installed using PyPi,
the UBI 8 image can be used.