### PR TITLE
Move off Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: generic
-sudo: required
-services: docker
-script:
-  - bash scripts/run-tests.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://travis-ci.org/release-engineering/estuary-api.svg?branch=master)](https://travis-ci.org/release-engineering/estuary-api)
 [![Docs Status](https://readthedocs.org/projects/estuary-api/badge/?version=latest)](https://estuary-api.readthedocs.io/en/latest/?badge=latest)
 
 # Getting Started


### PR DESCRIPTION
Due to the number of serious security incidents with Travis CI system, moving off Travis CI and probably will setup github actions to run the tests later.